### PR TITLE
[RFC] PHP 7 Support

### DIFF
--- a/DependencyInjection/JnsXhprofExtension.php
+++ b/DependencyInjection/JnsXhprofExtension.php
@@ -32,7 +32,7 @@ class JnsXhprofExtension extends Extension
         $config = $processor->process($configuration->getConfigTreeBuilder()->buildTree(), $configs);
 
         if ($config['enabled']) {
-            if (!$config['require_extension_exists'] || function_exists('xhprof_enable')) {
+            if (!$config['require_extension_exists'] || function_exists('xhprof_enable') || function_exists('tideways_enable')) {
                 $this->loadDefaults($container);
 
                 foreach ($config as $key => $value) {

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Make sure you have XHProf installed.
 If you are on a mac you can easily install it via [Macports][2]
     sudo port install php5-xhprof
 
+If you are using PHP 7 you can use the [Tideways XHProf fork](https://tideways.io/profiler/xhprof-for-php7-php5.6).
+
 1. ### Composer
 
   Add the following dependencies to your projects composer.json file:
@@ -36,7 +38,8 @@ If you are on a mac you can easily install it via [Macports][2]
     }
     ```
 
-  Of course, you have to install [xhprof library](http://php.net/manual/fr/book.xhprof.php) in your server.
+  Of course, you have to install [xhprof library](http://php.net/manual/fr/book.xhprof.php) (or for PHP 7 the
+  the [Tideways XHProf fork](https://tideways.io/profiler/xhprof-for-php7-php5.6)) in your server.
   At this moment, `ext-xhprof` is not required because your application could be deployed to a server without xhprof.
 
 2. ### Old way by adding to your vendor/bundles/ dir


### PR DESCRIPTION
This pr adds support for the [Tideways XHProf fork for PHP 7](https://tideways.io/profiler/xhprof-for-php7-php5.6).

Tested and working on my development machine.
